### PR TITLE
FIX stop_words_path in Rake class initialization

### DIFF
--- a/rake.py
+++ b/rake.py
@@ -122,7 +122,7 @@ def generate_candidate_keyword_scores(phrase_list, word_score):
 class Rake(object):
     def __init__(self, stop_words_path):
         self.stop_words_path = stop_words_path
-        self.__stop_words_pattern = build_stop_word_regex(stoppath)
+        self.__stop_words_pattern = build_stop_word_regex(stop_words_path)
 
     def run(self, text):
         sentence_list = split_sentences(text)


### PR DESCRIPTION
Looks like a bug. How tested is this code, btw?
